### PR TITLE
Arg scraping alternative

### DIFF
--- a/lib/boson.rb
+++ b/lib/boson.rb
@@ -1,4 +1,4 @@
-%w{hirb alias}.each {|e| require e }
+%w{hirb alias ruby_parser ruby2ruby}.each {|e| require e }
 %w{runner runners/console_runner repo manager loader inspector library}.each {|e| require "boson/#{e}" }
 %w{argument method comment}.each {|e| require "boson/inspectors/#{e}_inspector" }
 # order of library subclasses matters

--- a/lib/boson/inspector.rb
+++ b/lib/boson/inspector.rb
@@ -46,17 +46,25 @@ module Boson
 
         alias_method :_old_method_added, :method_added
         alias_method :method_added, :new_method_added
+
+        alias_method :_old_module_eval, :module_eval
+
+        def module_eval(*args)
+          # will return if called from disable
+          Boson::MethodInspector.parse_mod(self, args.first)
+          _old_module_eval(*args)
+        end
       ]
     ::Module.module_eval body
     end
 
     # Disable scraping method data.
     def disable
+      @enabled = false
       ::Module.module_eval %[
         Boson::MethodInspector::ALL_METHODS.each {|e| remove_method e }
         alias_method :method_added, :_old_method_added
-      ]
-      @enabled = false
+        alias_method :module_eval, :_old_module_eval                       ]
     end
 
     # Adds method attributes scraped for the library's module to the library's commands.

--- a/test/util_test.rb
+++ b/test/util_test.rb
@@ -98,7 +98,7 @@ describe "Util" do
 
     it "can see the difference between two methods with the same name" do
       alt_sexp = sexp_from(@mdalt)
-      alt_sexp.should.not == @mydef_sex_w_trace
+      alt_sexp.should.not == @mydef_sexp_w_trace
     end
 
     it "traces the last method with the same name" do


### PR DESCRIPTION
When the inspector tests for boson 0.3.4 and older didn't pass under rbx because of set_trace_func being used in argument_inspector, I asked the rbx guys for some alternatives. Evan Phoenix totally freaked out at the argument_inspector code, claiming that no one had any business using set_trace_func for anything other than a debugger and recommended only half a substitute: Method#parameters. I guess that exchange bothered me enough to keep this issue in the back of my mind all of these months.

This patch is a bit crazy: it steals module_eval but it was the best way I could think of to get at the raw source and parse it before it's added to Boson::Commands. Once I have the raw source in a parsed sexp form, then it's fairly easy to hollow out the method bodies, substitute in your original scraping code and then instance eval'ing that altered source code into the object that was extended by @current_module.

All of your original boson 3.4 inspector tests pass under every mri from 1.8.7 onwards with the exception of 1.9.1 which I haven't checked because I can't compile it on my laptop for some reason. And they pass on rbx 1.2.4 (1.8.7 compatible) and rbx.2.0.testing with the 1.8.7 mode set. The 1.9.3. mode is still buggy at this point.

Boson has never really worked on jruby and jruby barks a warning at me for stealing module_eval so this one is still on the todo list.

I've only glanced at Boson2 for a minute or so but it seems that you don't care about determining method argument vals any longer? I hope you haven't found a super simple way of doing that but in any case I had a lot of fun chasing this patch, thinking through using ruby at this level, and using some libraries (ruby_parser, sexp_processor, ruby2ruby) that to this point I had no conception of why or when I would ever need them.
