### PR TITLE
Handle case where no command is passed to help function

### DIFF
--- a/lib/boson/runner.rb
+++ b/lib/boson/runner.rb
@@ -91,7 +91,11 @@ module Boson
   # Defines default commands that are available to executables i.e. Runner.start
   class DefaultCommandsRunner < Runner
     desc "Displays help for a command"
-    def help(cmd)
+    def help(cmd = nil)
+      if cmd.nil?
+        puts "Usage: #{Runner.app_name} help COMMAND"
+        return
+      end
       (cmd_obj = Command.find(cmd)) ? Runner.current.display_command_help(cmd_obj) :
         self.class.no_command_error(cmd)
     end

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -132,9 +132,7 @@ STR
     end
     
     it 'prints usage if no command given' do
-      my_command('help').should ==<<-STR
-Usage: my_command help COMMAND
-STR
+      my_command('help').should == "Usage: my_command help COMMAND\n"
     end
     
     it 'prints usage if no command given with argument' do

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -278,7 +278,7 @@ STR
   describe "extend Runner" do
     it "can extend help" do
       extended_command('help help').should == <<-STR
-Usage: extended_command help CMD
+Usage: extended_command help [CMD]
 
 Description:
   Displays help for a command
@@ -288,7 +288,7 @@ STR
 
     it "can extend a command's --help" do
       extended_command('help -h').should == <<-STR
-Usage: extended_command help CMD
+Usage: extended_command help [CMD]
 
 Description:
   Displays help for a command

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -130,6 +130,18 @@ STR
         with("my_command: Could not find command \"invalid\"")
       my_command('help invalid')
     end
+    
+    it 'prints usage if no command given' do
+      my_command('help').should ==<<-STR
+Usage: my_command help COMMAND
+STR
+    end
+    
+    it 'prints usage if no command given with argument' do
+      my_command('help -f').should ==<<-STR
+Usage: my_command help COMMAND
+STR
+    end
   end
 
   describe "for COMMAND -h" do

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -138,9 +138,9 @@ STR
     end
     
     it 'prints usage if no command given with argument' do
-      my_command('help -f').should ==<<-STR
-Usage: my_command help COMMAND
-STR
+      capture_stderr {
+        my_command('help -f').chomp.should == "Usage: my_command help COMMAND"
+      }.should == "Deleted invalid option '-f'\n"
     end
   end
 


### PR DESCRIPTION
Hi,

If I enter something like 'my_app help' or 'my_app help -v' at the command line then the app crashes. This patch is intended to handle this case gracefully.

Regards,

Chris
