### PR TITLE
Handle case where help method is called with no command

### DIFF
--- a/lib/boson/runner.rb
+++ b/lib/boson/runner.rb
@@ -91,9 +91,13 @@ module Boson
   # Defines default commands that are available to executables i.e. Runner.start
   class DefaultCommandsRunner < Runner
     desc "Displays help for a command"
-    def help(cmd)
-      (cmd_obj = Command.find(cmd)) ? Runner.current.display_command_help(cmd_obj) :
-        self.class.no_command_error(cmd)
+    def help(cmd = nil)
+      if cmd.nil?
+        Runner.current.display_help()
+      else
+        (cmd_obj = Command.find(cmd)) ? Runner.current.display_command_help(cmd_obj) :
+          self.class.no_command_error(cmd)
+      end
     end
   end
 end

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -130,6 +130,10 @@ STR
         with("my_command: Could not find command \"invalid\"")
       my_command('help invalid')
     end
+    
+    it 'prints general help if no command' do
+      my_command('help').should == default_usage
+    end
   end
 
   describe "for COMMAND -h" do
@@ -285,7 +289,7 @@ STR
   describe "extend Runner" do
     it "can extend help" do
       extended_command('help help').should == <<-STR
-Usage: extended_command help CMD
+Usage: extended_command help [CMD]
 
 Description:
   Displays help for a command
@@ -295,7 +299,7 @@ STR
 
     it "can extend a command's --help" do
       extended_command('help -h').should == <<-STR
-Usage: extended_command help CMD
+Usage: extended_command help [CMD]
 
 Description:
   Displays help for a command


### PR DESCRIPTION
As discussed, this patch makes <code>my_app help</code> display general help. Cheers.
